### PR TITLE
(#21) :: Major CRD api

### DIFF
--- a/src/main/kotlin/kr/hs/entrydsm/exit/domain/document/persistence/element/WriterInfoElement.kt
+++ b/src/main/kotlin/kr/hs/entrydsm/exit/domain/document/persistence/element/WriterInfoElement.kt
@@ -1,6 +1,7 @@
 package kr.hs.entrydsm.exit.domain.document.persistence.element
 
 import kr.hs.entrydsm.exit.domain.major.persistence.Major
+import kr.hs.entrydsm.exit.domain.major.presentation.dto.response.MajorElement
 import kr.hs.entrydsm.exit.domain.student.persistence.Student
 import java.util.*
 
@@ -16,7 +17,7 @@ class WriterInfoElement (
     val number: String,
 
     val email: String,
-    val major: Major
+    val major: MajorElement
 
 ) {
     constructor(
@@ -33,7 +34,7 @@ class WriterInfoElement (
         number = student.number!!,
 
         email = student.email,
-        major = major
+        major = MajorElement(major)
     )
 
     fun updateVariableInfo(
@@ -41,13 +42,15 @@ class WriterInfoElement (
         grade: String,
         classNum: String,
         number: String,
-        major: Major
+        email: String,
+        major: MajorElement
     ): WriterInfoElement {
         return copy(
             profileImagePath = profileImagePath,
             grade = grade,
             classNum = classNum,
             number = number,
+            email = email,
             major = major
         )
     }
@@ -60,7 +63,7 @@ class WriterInfoElement (
         classNum: String = this.classNum,
         number: String  = this.number,
         email: String = this.email,
-        major: Major = this.major
+        major: MajorElement = this.major
     ): WriterInfoElement {
         return WriterInfoElement(
             studentId = studentId,

--- a/src/main/kotlin/kr/hs/entrydsm/exit/domain/major/persistence/Major.kt
+++ b/src/main/kotlin/kr/hs/entrydsm/exit/domain/major/persistence/Major.kt
@@ -2,7 +2,9 @@ package kr.hs.entrydsm.exit.domain.major.persistence
 
 import kr.hs.entrydsm.exit.global.entity.BaseUUIDEntity
 import javax.persistence.Entity
+import javax.persistence.Table
 
+@Table(name = "tbl_major")
 @Entity
 class Major(
      val name: String

--- a/src/main/kotlin/kr/hs/entrydsm/exit/domain/major/persistence/repository/MajorRepository.kt
+++ b/src/main/kotlin/kr/hs/entrydsm/exit/domain/major/persistence/repository/MajorRepository.kt
@@ -4,4 +4,6 @@ import kr.hs.entrydsm.exit.domain.major.persistence.Major
 import org.springframework.data.repository.CrudRepository
 import java.util.*
 
-interface MajorRepository: CrudRepository<Major, UUID>
+interface MajorRepository: CrudRepository<Major, UUID> {
+    fun findByNameContaining(name: String): List<Major>
+}

--- a/src/main/kotlin/kr/hs/entrydsm/exit/domain/major/presentation/MajorController.kt
+++ b/src/main/kotlin/kr/hs/entrydsm/exit/domain/major/presentation/MajorController.kt
@@ -1,0 +1,37 @@
+package kr.hs.entrydsm.exit.domain.major.presentation
+
+import kr.hs.entrydsm.exit.domain.major.presentation.dto.request.CreateMajorRequest
+import kr.hs.entrydsm.exit.domain.major.presentation.dto.request.DeleteMajorRequest
+import kr.hs.entrydsm.exit.domain.major.presentation.dto.response.MajorListResponse
+import kr.hs.entrydsm.exit.domain.major.usecase.CreateMajorUseCase
+import kr.hs.entrydsm.exit.domain.major.usecase.DeleteMajorUseCase
+import kr.hs.entrydsm.exit.domain.major.usecase.QueryMajorListUseCase
+import org.springframework.http.HttpStatus
+import org.springframework.web.bind.annotation.*
+
+@RequestMapping("/major")
+@RestController
+class MajorController(
+    private val createMajorUseCase: CreateMajorUseCase,
+    private val deleteMajorUseCase: DeleteMajorUseCase,
+    private val queryMajorUseCase: QueryMajorListUseCase
+) {
+
+    @ResponseStatus(HttpStatus.CREATED)
+    @PostMapping
+    fun createMajor(@RequestBody request: CreateMajorRequest) {
+        createMajorUseCase.execute(request)
+    }
+
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    @DeleteMapping
+    fun deleteMajor(@RequestBody request: DeleteMajorRequest) {
+        deleteMajorUseCase.execute(request)
+    }
+
+    @GetMapping
+    fun queryMajor(@RequestParam(value = "name") name: String = ""): MajorListResponse {
+        return queryMajorUseCase.execute(name)
+    }
+
+}

--- a/src/main/kotlin/kr/hs/entrydsm/exit/domain/major/presentation/dto/request/CreateMajorRequest.kt
+++ b/src/main/kotlin/kr/hs/entrydsm/exit/domain/major/presentation/dto/request/CreateMajorRequest.kt
@@ -1,0 +1,10 @@
+package kr.hs.entrydsm.exit.domain.major.presentation.dto.request
+
+import javax.validation.constraints.NotEmpty
+
+data class CreateMajorRequest(
+
+    @field:NotEmpty
+    val majorName: String
+
+)

--- a/src/main/kotlin/kr/hs/entrydsm/exit/domain/major/presentation/dto/request/DeleteMajorRequest.kt
+++ b/src/main/kotlin/kr/hs/entrydsm/exit/domain/major/presentation/dto/request/DeleteMajorRequest.kt
@@ -1,0 +1,11 @@
+package kr.hs.entrydsm.exit.domain.major.presentation.dto.request
+
+import org.jetbrains.annotations.NotNull
+import java.util.*
+
+data class DeleteMajorRequest(
+
+    @field:NotNull
+    val majorId: UUID
+
+)

--- a/src/main/kotlin/kr/hs/entrydsm/exit/domain/major/presentation/dto/response/MajorElement.kt
+++ b/src/main/kotlin/kr/hs/entrydsm/exit/domain/major/presentation/dto/response/MajorElement.kt
@@ -1,0 +1,14 @@
+package kr.hs.entrydsm.exit.domain.major.presentation.dto.response
+
+import kr.hs.entrydsm.exit.domain.major.persistence.Major
+import java.util.*
+
+data class MajorElement(
+    val majorId: UUID,
+    val name: String
+) {
+    constructor(major: Major) : this(
+        majorId = major.id,
+        name = major.name
+    )
+}

--- a/src/main/kotlin/kr/hs/entrydsm/exit/domain/major/presentation/dto/response/MajorListResponse.kt
+++ b/src/main/kotlin/kr/hs/entrydsm/exit/domain/major/presentation/dto/response/MajorListResponse.kt
@@ -1,0 +1,5 @@
+package kr.hs.entrydsm.exit.domain.major.presentation.dto.response
+
+data class MajorListResponse (
+    val majorList: List<MajorElement>
+)

--- a/src/main/kotlin/kr/hs/entrydsm/exit/domain/major/usecase/CreateMajorUseCase.kt
+++ b/src/main/kotlin/kr/hs/entrydsm/exit/domain/major/usecase/CreateMajorUseCase.kt
@@ -1,0 +1,22 @@
+package kr.hs.entrydsm.exit.domain.major.usecase
+
+import kr.hs.entrydsm.exit.domain.major.persistence.Major
+import kr.hs.entrydsm.exit.domain.major.persistence.repository.MajorRepository
+import kr.hs.entrydsm.exit.domain.major.presentation.dto.request.CreateMajorRequest
+import org.springframework.stereotype.Service
+import javax.transaction.Transactional
+
+@Service
+class CreateMajorUseCase(
+    private val majorRepository: MajorRepository
+) {
+    @Transactional
+    fun execute(request: CreateMajorRequest) {
+
+        majorRepository.save(
+            Major(
+                name = request.majorName
+            )
+        )
+    }
+}

--- a/src/main/kotlin/kr/hs/entrydsm/exit/domain/major/usecase/DeleteMajorUseCase.kt
+++ b/src/main/kotlin/kr/hs/entrydsm/exit/domain/major/usecase/DeleteMajorUseCase.kt
@@ -1,0 +1,21 @@
+package kr.hs.entrydsm.exit.domain.major.usecase
+
+import kr.hs.entrydsm.exit.domain.document.exception.MajorNotFoundException
+import kr.hs.entrydsm.exit.domain.major.persistence.repository.MajorRepository
+import kr.hs.entrydsm.exit.domain.major.presentation.dto.request.DeleteMajorRequest
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.stereotype.Service
+import javax.transaction.Transactional
+
+@Service
+class DeleteMajorUseCase(
+    private val majorRepository: MajorRepository
+) {
+    @Transactional
+    fun execute(request: DeleteMajorRequest) {
+
+        val major = majorRepository.findByIdOrNull(request.majorId) ?: throw MajorNotFoundException
+
+        majorRepository.deleteById(major.id)
+    }
+}

--- a/src/main/kotlin/kr/hs/entrydsm/exit/domain/major/usecase/QueryMajorListUseCase.kt
+++ b/src/main/kotlin/kr/hs/entrydsm/exit/domain/major/usecase/QueryMajorListUseCase.kt
@@ -1,0 +1,23 @@
+package kr.hs.entrydsm.exit.domain.major.usecase
+
+import kr.hs.entrydsm.exit.domain.major.persistence.repository.MajorRepository
+import kr.hs.entrydsm.exit.domain.major.presentation.dto.response.MajorElement
+import kr.hs.entrydsm.exit.domain.major.presentation.dto.response.MajorListResponse
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+class QueryMajorListUseCase(
+    private val majorRepository: MajorRepository
+) {
+    @Transactional(readOnly = false)
+    fun execute(name: String): MajorListResponse {
+
+        val tags = majorRepository.findByNameContaining(name)
+            .map { MajorElement(it) }
+            .toList()
+
+        return MajorListResponse(tags)
+    }
+
+}

--- a/src/main/kotlin/kr/hs/entrydsm/exit/global/security/SecurityConfig.kt
+++ b/src/main/kotlin/kr/hs/entrydsm/exit/global/security/SecurityConfig.kt
@@ -49,6 +49,11 @@ internal class SecurityConfig(
             // DOCUMENT
             .antMatchers(HttpMethod.POST, "/document").hasAuthority(STUDENT)
 
+            // MAJOR
+            .antMatchers(HttpMethod.GET, "/major").hasAnyAuthority(STUDENT, TEACHER, COMPANY)
+            .antMatchers(HttpMethod.POST, "/major").hasAuthority(TEACHER)
+            .antMatchers(HttpMethod.DELETE, "/major").hasAuthority(TEACHER)
+
             .anyRequest().permitAll()
 
         http


### PR DESCRIPTION
close #21 

- 전공 Entity 생성, 수정, 삭제 api
- Document의 WriterInfoElement 안에 들어가있는 Major를 VO(MajorElement)로 변경
    - Document 조회시 Major가 영속성 컨텍스트에서 관리될 가능성 있음