### PR TITLE
(#26) :: 테스트 코드

### DIFF
--- a/src/main/kotlin/kr/hs/entrydsm/exit/domain/auth/presentation/dto/request/SendPhoneNumberCodeRequest.kt
+++ b/src/main/kotlin/kr/hs/entrydsm/exit/domain/auth/presentation/dto/request/SendPhoneNumberCodeRequest.kt
@@ -1,8 +1,11 @@
 package kr.hs.entrydsm.exit.domain.auth.presentation.dto.request
 
+import kr.hs.entrydsm.exit.global.util.RegexUtil
 import org.hibernate.validator.constraints.Length
+import org.intellij.lang.annotations.Pattern
 
 data class SendPhoneNumberCodeRequest(
-    @field:Length(min = 10, max = 11)
+    @field:Pattern(RegexUtil.NUMBER_EXP)
+    @field:Length(min = 11, max = 11)
     val phoneNumber: String
 )

--- a/src/test/kotlin/kr/hs/entrydsm/exit/common/AnyValueObjectGenerator.kt
+++ b/src/test/kotlin/kr/hs/entrydsm/exit/common/AnyValueObjectGenerator.kt
@@ -1,0 +1,60 @@
+package kr.hs.entrydsm.exit.common
+
+import java.util.*
+import kotlin.reflect.KClass
+import kotlin.reflect.full.primaryConstructor
+
+object AnyValueObjectGenerator {
+
+    inline fun <reified T : Any> anyValueObject(vararg pairs: Pair<String, Any>): T {
+
+        val parameterMap = mutableMapOf(*pairs)
+        val constructor = T::class.primaryConstructor!!
+
+        val params = constructor.parameters.map {
+            val cls = it.type.classifier as KClass<*>
+            if (parameterMap[it.name] != null) parameterMap.remove(it.name) else anyValue(cls, it.isOptional)
+        }
+
+        if (parameterMap.isNotEmpty()) {
+            throw IllegalArgumentException("Map contains pairs with invalid name or type. $parameterMap")
+        }
+
+        return constructor.call(*params.toTypedArray())
+    }
+
+    fun anyValue(cls: KClass<*>, isNullable: Boolean): Any? {
+
+        if (isNullable) return null
+
+        return when (cls) {
+            Boolean::class -> false
+            Byte::class -> 0.toByte()
+            Short::class -> 0.toShort()
+            Char::class -> 0.toChar()
+            Int::class -> 0
+            Long::class -> 0L
+            Float::class -> 0.0F
+            Double::class -> 0.0
+            String::class -> ""
+            Date::class -> Date(0)
+            UUID::class -> UUID.randomUUID()
+
+            BooleanArray::class -> BooleanArray(0)
+            ByteArray::class -> ByteArray(0)
+            CharArray::class -> CharArray(0)
+            IntArray::class -> IntArray(0)
+            LongArray::class -> LongArray(0)
+            DoubleArray::class -> DoubleArray(0)
+
+            List::class -> List<Any>(0) {}
+            Map::class -> HashMap<Any, Any>()
+            Set::class -> HashSet<Any>()
+            ArrayList::class -> ArrayList<Any>()
+            HashMap::class -> HashMap<Any, Any>()
+            HashSet::class -> HashSet<Any>()
+
+            else -> { throw IllegalArgumentException("Fields of type ${cls.qualifiedName} cannot automatically generate values") }
+        }
+    }
+}

--- a/src/test/kotlin/kr/hs/entrydsm/exit/common/Specs.kt
+++ b/src/test/kotlin/kr/hs/entrydsm/exit/common/Specs.kt
@@ -1,0 +1,10 @@
+package kr.hs.entrydsm.exit.common
+
+import io.kotest.core.spec.Spec
+import io.mockk.clearAllMocks
+
+fun Spec.afterContainer() {
+    afterContainer {
+        clearAllMocks()
+    }
+}

--- a/src/test/kotlin/kr/hs/entrydsm/exit/common/TestObjects.kt
+++ b/src/test/kotlin/kr/hs/entrydsm/exit/common/TestObjects.kt
@@ -1,0 +1,23 @@
+package kr.hs.entrydsm.exit.common
+
+import kr.hs.entrydsm.exit.common.AnyValueObjectGenerator.anyValueObject
+import kr.hs.entrydsm.exit.domain.document.persistence.Document
+import kr.hs.entrydsm.exit.domain.document.persistence.element.WriterInfoElement
+import kr.hs.entrydsm.exit.domain.document.persistence.enums.Status
+import kr.hs.entrydsm.exit.domain.major.persistence.Major
+import kr.hs.entrydsm.exit.domain.student.persistence.Student
+import java.util.*
+
+
+fun getTestDocument(
+    student: Student = anyValueObject(),
+    major: Major = anyValueObject(),
+    status: Status = Status.CREATED
+) = Document(
+    id = UUID.randomUUID(),
+    writer = WriterInfoElement(
+        student = student,
+        major = major
+    ),
+    status = status
+)

--- a/src/test/kotlin/kr/hs/entrydsm/exit/domain/auth/usecase/ReceivePhoneNumberVerificationCodeUseCaseTest.kt
+++ b/src/test/kotlin/kr/hs/entrydsm/exit/domain/auth/usecase/ReceivePhoneNumberVerificationCodeUseCaseTest.kt
@@ -1,0 +1,61 @@
+package kr.hs.entrydsm.exit.domain.auth.usecase
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.DescribeSpec
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import kr.hs.entrydsm.exit.common.AnyValueObjectGenerator.anyValueObject
+import kr.hs.entrydsm.exit.common.afterContainer
+import kr.hs.entrydsm.exit.domain.auth.exception.VerificationCodeMismatchedException
+import kr.hs.entrydsm.exit.domain.auth.persistence.PhoneNumberVerificationCode
+import kr.hs.entrydsm.exit.domain.auth.persistence.properties.PhoneNumberVerificationCodeProperties
+import kr.hs.entrydsm.exit.domain.auth.persistence.repository.PhoneNumberVerificationCodeRepository
+import org.springframework.data.repository.findByIdOrNull
+
+internal class ReceivePhoneNumberVerificationCodeUseCaseTest : DescribeSpec({
+
+    val phoneNumberVerificationCodeRepository: PhoneNumberVerificationCodeRepository = mockk()
+    val properties: PhoneNumberVerificationCodeProperties = anyValueObject()
+
+    val receivePhoneNumberVerificationCodeUseCase = ReceivePhoneNumberVerificationCodeUseCase(phoneNumberVerificationCodeRepository, properties)
+
+    describe("receivePhoneNumberVerificationCode"){
+
+        val phoneNumber = "01012345678"
+        val code = "123456"
+        val phoneNumberVerificationCode = anyValueObject<PhoneNumberVerificationCode>(
+            "code" to code
+        )
+
+        context("전화번호와 코드가 주어지면") {
+
+            every { phoneNumberVerificationCodeRepository.findByIdOrNull(phoneNumber) } returns phoneNumberVerificationCode
+            every { phoneNumberVerificationCodeRepository.save(any()) } returnsArgument 0
+
+            it("저장된 코드를 인증상태로 변경한다.") {
+
+                receivePhoneNumberVerificationCodeUseCase.execute(phoneNumber, code)
+
+                verify(exactly = 1) { phoneNumberVerificationCodeRepository.save(any()) }
+            }
+        }
+
+        val wrongCode = "234567"
+
+        context("잘못된 코드가 주어지면") {
+
+            every { phoneNumberVerificationCodeRepository.findByIdOrNull(phoneNumber) } returns phoneNumberVerificationCode
+            every { phoneNumberVerificationCodeRepository.save(any()) } returnsArgument 0
+
+            it("VerificationCodeMismatched 예외를 던진다.") {
+                shouldThrow<VerificationCodeMismatchedException> {
+                    receivePhoneNumberVerificationCodeUseCase.execute(phoneNumber, wrongCode)
+                }
+                verify(exactly = 0) { phoneNumberVerificationCodeRepository.save(any()) }
+            }
+        }
+    }
+
+    afterContainer()
+})

--- a/src/test/kotlin/kr/hs/entrydsm/exit/domain/auth/usecase/SendPhoneNumberVerificationCodeUseCaseTest.kt
+++ b/src/test/kotlin/kr/hs/entrydsm/exit/domain/auth/usecase/SendPhoneNumberVerificationCodeUseCaseTest.kt
@@ -1,0 +1,108 @@
+package kr.hs.entrydsm.exit.domain.auth.usecase
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import io.mockk.*
+import kr.hs.entrydsm.exit.common.AnyValueObjectGenerator.anyValueObject
+import kr.hs.entrydsm.exit.common.afterContainer
+import kr.hs.entrydsm.exit.domain.auth.exception.AlreadyVerifiedException
+import kr.hs.entrydsm.exit.domain.auth.exception.TooManySendVerificationException
+import kr.hs.entrydsm.exit.domain.auth.persistence.PhoneNumberVerificationCode
+import kr.hs.entrydsm.exit.domain.auth.persistence.properties.PhoneNumberVerificationCodeProperties
+import kr.hs.entrydsm.exit.domain.auth.persistence.repository.PhoneNumberVerificationCodeRepository
+import kr.hs.entrydsm.exit.global.util.GenerateRandomCodeUtil
+import org.springframework.data.repository.findByIdOrNull
+
+internal class SendPhoneNumberVerificationCodeUseCaseTest : DescribeSpec({
+
+    val phoneNumberVerificationCodeRepository: PhoneNumberVerificationCodeRepository = mockk()
+    val properties: PhoneNumberVerificationCodeProperties = anyValueObject(
+        "limitCountOfSend" to 3,
+        "codeLength" to 6
+    )
+    mockkObject(GenerateRandomCodeUtil)
+
+    val sendPhoneNumberVerificationCodeUseCase = SendPhoneNumberVerificationCodeUseCase(phoneNumberVerificationCodeRepository, properties)
+
+    describe("sendPhoneNumberVerificationCode") {
+
+        val phoneNumber = anyValueObject<String>()
+
+        context("아직 인증코드가 생성되어있지 않은 전화번호를 받으면") {
+
+            val slot = slot<PhoneNumberVerificationCode>()
+
+            every { phoneNumberVerificationCodeRepository.findByIdOrNull(phoneNumber) } returns null
+            every { phoneNumberVerificationCodeRepository.save(capture(slot)) } returnsArgument 0
+
+            it("랜덤 코드를 생성하여 sms로 전송한다.") {
+
+                sendPhoneNumberVerificationCodeUseCase.execute(phoneNumber)
+
+                verify(exactly = 1) { phoneNumberVerificationCodeRepository.save(any()) }
+                slot.captured.countOfSend shouldBe 1
+            }
+        }
+
+        val countOfSend = 0
+        val phoneNumberVerificationCode = anyValueObject<PhoneNumberVerificationCode>(
+            "countOfSend" to countOfSend
+        )
+
+        context("인증코드가 생성되어있는 전화번호를 받으면") {
+
+            val slot = slot<PhoneNumberVerificationCode>()
+
+            every { phoneNumberVerificationCodeRepository.findByIdOrNull(phoneNumber) } returns phoneNumberVerificationCode
+            every { phoneNumberVerificationCodeRepository.save(capture(slot)) } returnsArgument 0
+
+            it("전송 횟수를 증가시킨 후 새 랜덤 코드를 sms로 전송한다.") {
+
+                sendPhoneNumberVerificationCodeUseCase.execute(phoneNumber)
+
+                verify(exactly = 1) { phoneNumberVerificationCodeRepository.save(any()) }
+                slot.captured.code shouldNotBe phoneNumberVerificationCode.code
+                slot.captured.countOfSend shouldBe countOfSend + 1
+            }
+        }
+
+        val exceededCountOfSend = 3
+        val codeExceededCountOfSend = anyValueObject<PhoneNumberVerificationCode>(
+            "countOfSend" to exceededCountOfSend
+        )
+
+        context("인증 요청 횟수가 초과한 전화번호를 받으면") {
+
+            every { phoneNumberVerificationCodeRepository.findByIdOrNull(phoneNumber) } returns codeExceededCountOfSend
+
+            it("TooManySendVerification 예외를 던진다.") {
+
+                shouldThrow<TooManySendVerificationException> {
+                    sendPhoneNumberVerificationCodeUseCase.execute(phoneNumber)
+                }
+                verify(exactly = 0) { phoneNumberVerificationCodeRepository.save(any()) }
+            }
+        }
+
+        val alreadyVerifiedCode = anyValueObject<PhoneNumberVerificationCode>(
+            "isVerified" to true
+        )
+
+        context("이미 인증된 전화번호를 받으면") {
+
+            every { phoneNumberVerificationCodeRepository.findByIdOrNull(phoneNumber) } returns alreadyVerifiedCode
+
+            it("AlreadyVerified 예외를 던진다.") {
+
+                shouldThrow<AlreadyVerifiedException> {
+                    sendPhoneNumberVerificationCodeUseCase.execute(phoneNumber)
+                }
+                verify(exactly = 0) { phoneNumberVerificationCodeRepository.save(any()) }
+            }
+        }
+    }
+
+    afterContainer()
+})

--- a/src/test/kotlin/kr/hs/entrydsm/exit/domain/company/usecase/AllowStandbyCompanyUseCaseTest.kt
+++ b/src/test/kotlin/kr/hs/entrydsm/exit/domain/company/usecase/AllowStandbyCompanyUseCaseTest.kt
@@ -1,0 +1,43 @@
+package kr.hs.entrydsm.exit.domain.company.usecase
+
+import io.kotest.core.spec.style.DescribeSpec
+import io.mockk.every
+import io.mockk.justRun
+import io.mockk.mockk
+import io.mockk.verify
+import kr.hs.entrydsm.exit.common.AnyValueObjectGenerator.anyValueObject
+import kr.hs.entrydsm.exit.common.afterContainer
+import kr.hs.entrydsm.exit.domain.company.persistence.StandbyCompany
+import kr.hs.entrydsm.exit.domain.company.persistence.repository.CompanyRepository
+import kr.hs.entrydsm.exit.domain.company.persistence.repository.StandbyCompanyRepository
+import org.springframework.data.repository.findByIdOrNull
+
+
+internal class AllowStandbyCompanyUseCaseTest : DescribeSpec({
+
+    val standbyCompanyRepository = mockk<StandbyCompanyRepository>()
+    val companyRepository = mockk<CompanyRepository>()
+
+    val allowStandByCompanyUseCase = AllowStandbyCompanyUseCase(standbyCompanyRepository, companyRepository)
+
+    describe("allowStandByCompany") {
+
+        val standByCompany = anyValueObject<StandbyCompany>()
+
+        context("대기중인 회사의 id가 주어지면") {
+
+            every { standbyCompanyRepository.findByIdOrNull(standByCompany.id) } returns standByCompany
+            every { companyRepository.save(any()) } returnsArgument 0
+            justRun { standbyCompanyRepository.delete(standByCompany) }
+
+            it("승인된 회사로 저장한뒤 기존 정보를 삭제한다.") {
+
+                allowStandByCompanyUseCase.execute(standByCompany.id)
+                verify(exactly = 1) { companyRepository.save(any()) }
+                verify(exactly = 1) { standbyCompanyRepository.delete(standByCompany) }
+            }
+        }
+    }
+
+    afterContainer()
+})

--- a/src/test/kotlin/kr/hs/entrydsm/exit/domain/company/usecase/CompanySignUpUseCaseTest.kt
+++ b/src/test/kotlin/kr/hs/entrydsm/exit/domain/company/usecase/CompanySignUpUseCaseTest.kt
@@ -1,0 +1,82 @@
+package kr.hs.entrydsm.exit.domain.company.usecase
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.DescribeSpec
+import io.mockk.every
+import io.mockk.justRun
+import io.mockk.mockk
+import io.mockk.verify
+import kr.hs.entrydsm.exit.common.AnyValueObjectGenerator.anyValueObject
+import kr.hs.entrydsm.exit.common.afterContainer
+import kr.hs.entrydsm.exit.domain.auth.exception.NotVerifiedException
+import kr.hs.entrydsm.exit.domain.auth.persistence.PhoneNumberVerificationCode
+import kr.hs.entrydsm.exit.domain.auth.persistence.repository.PhoneNumberVerificationCodeRepository
+import kr.hs.entrydsm.exit.domain.company.persistence.repository.StandbyCompanyRepository
+import kr.hs.entrydsm.exit.domain.company.presentation.dto.request.CompanySignUpRequest
+import org.springframework.data.repository.findByIdOrNull
+
+internal class CompanySignUpUseCaseTest  : DescribeSpec({
+
+    val standByCompanyRepository = mockk<StandbyCompanyRepository>()
+    val phoneNumberVerificationCodeRepository = mockk<PhoneNumberVerificationCodeRepository>()
+
+    val companySignUpUseCase = CompanySignUpUseCase(standByCompanyRepository, phoneNumberVerificationCodeRepository)
+
+    describe("companySignUp") {
+
+        val phoneNumberVerificationCode =
+            anyValueObject<PhoneNumberVerificationCode>(
+                "isVerified" to true
+            )
+
+        val request = anyValueObject<CompanySignUpRequest>()
+
+        context("회사 정보가 주어지면") {
+
+            every { phoneNumberVerificationCodeRepository.findByIdOrNull(request.phoneNumber) } returns phoneNumberVerificationCode
+            justRun { phoneNumberVerificationCodeRepository.delete(phoneNumberVerificationCode) }
+            every { standByCompanyRepository.save(any()) } returnsArgument 0
+
+            it("승인 대기 회사로 저장한다.") {
+
+                companySignUpUseCase.execute(request)
+                verify(exactly = 1) { phoneNumberVerificationCodeRepository.delete(phoneNumberVerificationCode) }
+                verify(exactly = 1) { standByCompanyRepository.save(any()) }
+            }
+        }
+
+        context("전화번호가 null인 회사 정보가 주어지면") {
+
+            every { phoneNumberVerificationCodeRepository.findByIdOrNull(request.phoneNumber) } returns null
+
+            it("NotVerified 예외를 던진다.") {
+
+                shouldThrow<NotVerifiedException> {
+                    companySignUpUseCase.execute(request)
+                }
+                verify(exactly = 0) { phoneNumberVerificationCodeRepository.delete(phoneNumberVerificationCode) }
+                verify(exactly = 0) { standByCompanyRepository.save(any()) }
+            }
+        }
+
+        val notVerifiedCode = anyValueObject<PhoneNumberVerificationCode>(
+            "isVerified" to false
+        )
+
+        context("전화번호가 인증되지 않은 회사 정보가 주어지면") {
+
+            every { phoneNumberVerificationCodeRepository.findByIdOrNull(request.phoneNumber) } returns notVerifiedCode
+
+            it("NotVerified 예외를 던진다.") {
+
+                shouldThrow<NotVerifiedException> {
+                    companySignUpUseCase.execute(request)
+                }
+                verify(exactly = 0) { phoneNumberVerificationCodeRepository.delete(phoneNumberVerificationCode) }
+                verify(exactly = 0) { standByCompanyRepository.save(any()) }
+            }
+        }
+    }
+
+    afterContainer()
+})

--- a/src/test/kotlin/kr/hs/entrydsm/exit/domain/company/usecase/RejectStandbyCompanyUseCaseTest.kt
+++ b/src/test/kotlin/kr/hs/entrydsm/exit/domain/company/usecase/RejectStandbyCompanyUseCaseTest.kt
@@ -1,0 +1,38 @@
+package kr.hs.entrydsm.exit.domain.company.usecase
+
+import io.kotest.core.spec.style.DescribeSpec
+import io.mockk.every
+import io.mockk.justRun
+import io.mockk.mockk
+import io.mockk.verify
+import kr.hs.entrydsm.exit.common.AnyValueObjectGenerator.anyValueObject
+import kr.hs.entrydsm.exit.common.afterContainer
+import kr.hs.entrydsm.exit.domain.company.persistence.StandbyCompany
+import kr.hs.entrydsm.exit.domain.company.persistence.repository.StandbyCompanyRepository
+import org.springframework.data.repository.findByIdOrNull
+
+internal class RejectStandbyCompanyUseCaseTest : DescribeSpec({
+
+    val standbyCompanyRepository = mockk<StandbyCompanyRepository>()
+
+    val rejectStandByCompanyUseCase = RejectStandbyCompanyUseCase(standbyCompanyRepository)
+
+    describe("rejectStandbyCompany") {
+
+        val standByCompany = anyValueObject<StandbyCompany>()
+
+        context("대기중인 회사의 id가 주어지면") {
+
+            every { standbyCompanyRepository.findByIdOrNull(standByCompany.id) } returns standByCompany
+            justRun { standbyCompanyRepository.delete(standByCompany) }
+
+            it("정보를 삭제한다.") {
+
+                rejectStandByCompanyUseCase.execute(standByCompany.id)
+                verify(exactly = 1) { standbyCompanyRepository.delete(standByCompany) }
+            }
+        }
+    }
+
+    afterContainer()
+})

--- a/src/test/kotlin/kr/hs/entrydsm/exit/domain/document/usecase/CreateDocumentUseCaseTest.kt
+++ b/src/test/kotlin/kr/hs/entrydsm/exit/domain/document/usecase/CreateDocumentUseCaseTest.kt
@@ -1,0 +1,84 @@
+package kr.hs.entrydsm.exit.domain.document.usecase
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkObject
+import kr.hs.entrydsm.exit.common.AnyValueObjectGenerator.anyValueObject
+import kr.hs.entrydsm.exit.common.afterContainer
+import kr.hs.entrydsm.exit.common.getTestDocument
+import kr.hs.entrydsm.exit.domain.document.exception.DocumentAlreadyExistException
+import kr.hs.entrydsm.exit.domain.document.exception.MajorNotFoundException
+import kr.hs.entrydsm.exit.domain.document.persistence.repository.DocumentRepository
+import kr.hs.entrydsm.exit.domain.document.presentation.dto.request.CreateDocumentRequest
+import kr.hs.entrydsm.exit.domain.major.persistence.Major
+import kr.hs.entrydsm.exit.domain.major.persistence.repository.MajorRepository
+import kr.hs.entrydsm.exit.domain.student.persistence.Student
+import kr.hs.entrydsm.exit.global.security.SecurityUtil
+import org.springframework.data.repository.findByIdOrNull
+
+internal class CreateDocumentUseCaseTest : DescribeSpec({
+
+    val documentRepository: DocumentRepository = mockk()
+    val majorRepository: MajorRepository = mockk()
+    mockkObject(SecurityUtil)
+
+    val createDocumentUseCase = CreateDocumentUseCase(documentRepository, majorRepository)
+
+    describe("createDocument") {
+
+        val student = anyValueObject<Student>()
+        val major = anyValueObject<Major>()
+        val document = getTestDocument(student, major)
+
+        val request = CreateDocumentRequest(major.id)
+
+        context("아직 문서를 생성하지 않은 학생과 전공의 정보가 주어지면") {
+
+            every { SecurityUtil.getCurrentStudent() } returns student
+            every { documentRepository.findByWriterStudentId(student.id) } returns null
+            every { majorRepository.findByIdOrNull(request.majorId) } returns major
+            every { documentRepository.save(any()) } returns document
+
+            it("문서를 생성한다.") {
+
+                val response = createDocumentUseCase.execute(request)
+                response.documentId shouldBe document.id
+            }
+        }
+
+        context("이미 문서를 생성한 학생과 전공의 정보가 주어지면") {
+
+            every { SecurityUtil.getCurrentStudent() } returns student
+            every { documentRepository.findByWriterStudentId(student.id) } returns document
+            every { majorRepository.findByIdOrNull(request.majorId) } returns major
+            every { documentRepository.save(any()) } returns document
+
+            it("DocumentAlreadyExist 예외를 던진다.") {
+
+                shouldThrow<DocumentAlreadyExistException> {
+                    createDocumentUseCase.execute(request)
+                }
+            }
+        }
+
+        context("주어진 Major의 id가 잘못되었으면") {
+
+            every { SecurityUtil.getCurrentStudent() } returns student
+            every { documentRepository.findByWriterStudentId(student.id) } returns null
+            every { majorRepository.findByIdOrNull(request.majorId) } returns null
+
+            it("MajorNotFound 예외를 던진다.") {
+
+                shouldThrow<MajorNotFoundException> {
+                    createDocumentUseCase.execute(request)
+                }
+            }
+        }
+
+    }
+
+    afterContainer()
+})

--- a/src/test/kotlin/kr/hs/entrydsm/exit/domain/document/usecase/ShareDocumentUseCaseTest.kt
+++ b/src/test/kotlin/kr/hs/entrydsm/exit/domain/document/usecase/ShareDocumentUseCaseTest.kt
@@ -1,0 +1,76 @@
+package kr.hs.entrydsm.exit.domain.document.usecase
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import kr.hs.entrydsm.exit.common.afterContainer
+import kr.hs.entrydsm.exit.common.getTestDocument
+import kr.hs.entrydsm.exit.domain.document.exception.IllegalStatusException
+import kr.hs.entrydsm.exit.domain.document.persistence.Document
+import kr.hs.entrydsm.exit.domain.document.persistence.enums.Status
+import kr.hs.entrydsm.exit.domain.document.persistence.repository.DocumentRepository
+import org.springframework.data.repository.findByIdOrNull
+
+internal class ShareDocumentUseCaseTest : DescribeSpec({
+
+    val documentRepository: DocumentRepository = mockk()
+
+    val shareDocumentUseCase = ShareDocumentUseCase(documentRepository)
+
+    describe("shareDocument") {
+
+        val document = getTestDocument(status = Status.SUBMITTED)
+
+        context("SUBMITTED 상태인 문서의 id가 주어지면") {
+
+            val slot = slot<Document>()
+
+            every { documentRepository.findByIdOrNull(document.id) } returns document
+            every { documentRepository.save(capture(slot)) } returnsArgument 0
+
+            it("해당 문서를 SHARED 상태로 변경하여 저장한다.") {
+
+                shareDocumentUseCase.execute(document.id)
+
+                verify(exactly = 1) { documentRepository.save(slot.captured) }
+                slot.captured.status shouldBe Status.SHARED
+            }
+        }
+
+        val createdDocument = getTestDocument(status = Status.CREATED)
+
+        context("CREATED 상태인 문서의 id가 주어지면") {
+
+            every { documentRepository.findByIdOrNull(createdDocument.id) } returns createdDocument
+
+            it("IllegalStatus 예외를 던진다.") {
+
+                shouldThrow<IllegalStatusException> {
+                    shareDocumentUseCase.execute(createdDocument.id)
+                }
+                verify(exactly = 0) { documentRepository.save(any()) }
+            }
+        }
+
+        val sharedDocument = getTestDocument(status = Status.SHARED)
+
+        context("SHARED 상태인 문서의 id가 주어지면") {
+
+            every { documentRepository.findByIdOrNull(sharedDocument.id) } returns sharedDocument
+
+            it("IllegalStatus 예외를 던진다.") {
+
+                shouldThrow<IllegalStatusException> {
+                    shareDocumentUseCase.execute(sharedDocument.id)
+                }
+                verify(exactly = 0) { documentRepository.save(any()) }
+            }
+        }
+    }
+
+    afterContainer()
+})

--- a/src/test/kotlin/kr/hs/entrydsm/exit/domain/document/usecase/UpdateAwardUseCaseTest.kt
+++ b/src/test/kotlin/kr/hs/entrydsm/exit/domain/document/usecase/UpdateAwardUseCaseTest.kt
@@ -1,0 +1,63 @@
+package kr.hs.entrydsm.exit.domain.document.usecase
+
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import io.mockk.*
+import kr.hs.entrydsm.exit.common.AnyValueObjectGenerator.anyValueObject
+import kr.hs.entrydsm.exit.common.afterContainer
+import kr.hs.entrydsm.exit.common.getTestDocument
+import kr.hs.entrydsm.exit.domain.document.persistence.Document
+import kr.hs.entrydsm.exit.domain.document.persistence.repository.DocumentRepository
+import kr.hs.entrydsm.exit.domain.document.presentation.dto.request.UpdateAwardRequest
+import kr.hs.entrydsm.exit.domain.document.presentation.dto.request.UpdateAwardRequest.AwardRequest
+import kr.hs.entrydsm.exit.domain.student.persistence.Student
+import kr.hs.entrydsm.exit.global.security.SecurityUtil
+
+internal class UpdateAwardUseCaseTest : DescribeSpec({
+
+    val documentRepository: DocumentRepository = mockk()
+    mockkObject(SecurityUtil)
+
+    val updateAwardUseCase = UpdateAwardUseCase(documentRepository)
+
+    describe("updateAward") {
+
+        val student = anyValueObject<Student>()
+        val document = getTestDocument(student)
+
+        val request = anyValueObject<UpdateAwardRequest>(
+            "awardList" to listOf(anyValueObject<AwardRequest>())
+        )
+
+        context("수상경력 데이터를 받으면") {
+
+            val slot = slot<Document>()
+
+            every { SecurityUtil.getCurrentStudent() } returns student
+            every { documentRepository.findByWriterStudentId(student.id) } returns document
+            every { documentRepository.save(capture(slot)) } returnsArgument 0
+
+            it("본인(학생) 문서의 정보를 수정한다.") {
+
+                updateAwardUseCase.execute(request)
+                onlyAwardIsDifferent(slot, document)
+            }
+        }
+    }
+
+    afterContainer()
+})
+
+private fun onlyAwardIsDifferent(
+    slot: CapturingSlot<Document>,
+    document: Document
+) {
+    slot.captured.id shouldBe document.id
+    slot.captured.writer shouldBe document.writer
+    slot.captured.introduce shouldBe document.introduce
+    slot.captured.skillSet shouldBe document.skillSet
+    slot.captured.projectList shouldBe document.projectList
+    slot.captured.awardList shouldNotBe document.awardList
+    slot.captured.certificateList shouldBe document.certificateList
+}

--- a/src/test/kotlin/kr/hs/entrydsm/exit/domain/document/usecase/UpdateCertificateUseCaseTest.kt
+++ b/src/test/kotlin/kr/hs/entrydsm/exit/domain/document/usecase/UpdateCertificateUseCaseTest.kt
@@ -1,0 +1,63 @@
+package kr.hs.entrydsm.exit.domain.document.usecase
+
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import io.mockk.*
+import kr.hs.entrydsm.exit.common.AnyValueObjectGenerator.anyValueObject
+import kr.hs.entrydsm.exit.common.afterContainer
+import kr.hs.entrydsm.exit.common.getTestDocument
+import kr.hs.entrydsm.exit.domain.document.persistence.Document
+import kr.hs.entrydsm.exit.domain.document.persistence.repository.DocumentRepository
+import kr.hs.entrydsm.exit.domain.document.presentation.dto.request.UpdateCertificateRequest
+import kr.hs.entrydsm.exit.domain.document.presentation.dto.request.UpdateCertificateRequest.CertificateRequest
+import kr.hs.entrydsm.exit.domain.student.persistence.Student
+import kr.hs.entrydsm.exit.global.security.SecurityUtil
+
+internal class UpdateCertificateUseCaseTest : DescribeSpec({
+
+    val documentRepository: DocumentRepository = mockk()
+    mockkObject(SecurityUtil)
+
+    val updateCertificateUseCase = UpdateCertificateUseCase(documentRepository)
+
+    describe("updateCertificate") {
+
+        val student = anyValueObject<Student>()
+        val document = getTestDocument(student)
+
+        val request = anyValueObject<UpdateCertificateRequest>(
+            "certificateList" to listOf(anyValueObject<CertificateRequest>())
+        )
+
+        context("자격증 데이터를 받으면") {
+
+            val slot = slot<Document>()
+
+            every { SecurityUtil.getCurrentStudent() } returns student
+            every { documentRepository.findByWriterStudentId(student.id) } returns document
+            every { documentRepository.save(capture(slot)) } returnsArgument 0
+
+            it("본인(학생) 문서의 자격증 정보를 수정한다.") {
+
+                updateCertificateUseCase.execute(request)
+                onlyCertificateIsDifferent(slot, document)
+            }
+        }
+    }
+
+    afterContainer()
+})
+
+private fun onlyCertificateIsDifferent(
+    slot: CapturingSlot<Document>,
+    document: Document
+) {
+    slot.captured.id shouldBe document.id
+    slot.captured.writer shouldBe document.writer
+    slot.captured.introduce shouldBe document.introduce
+    slot.captured.skillSet shouldBe document.skillSet
+    slot.captured.projectList shouldBe document.projectList
+    slot.captured.awardList shouldBe document.awardList
+    slot.captured.certificateList shouldNotBe document.certificateList
+}

--- a/src/test/kotlin/kr/hs/entrydsm/exit/domain/document/usecase/UpdateIntroduceUseCaseTest.kt
+++ b/src/test/kotlin/kr/hs/entrydsm/exit/domain/document/usecase/UpdateIntroduceUseCaseTest.kt
@@ -1,0 +1,60 @@
+package kr.hs.entrydsm.exit.domain.document.usecase
+
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import io.mockk.*
+import kr.hs.entrydsm.exit.common.AnyValueObjectGenerator.anyValueObject
+import kr.hs.entrydsm.exit.common.afterContainer
+import kr.hs.entrydsm.exit.common.getTestDocument
+import kr.hs.entrydsm.exit.domain.document.persistence.Document
+import kr.hs.entrydsm.exit.domain.document.persistence.repository.DocumentRepository
+import kr.hs.entrydsm.exit.domain.document.presentation.dto.request.UpdateIntroduceRequest
+import kr.hs.entrydsm.exit.domain.student.persistence.Student
+import kr.hs.entrydsm.exit.global.security.SecurityUtil
+
+internal class UpdateIntroduceUseCaseTest : DescribeSpec({
+
+    val documentRepository: DocumentRepository = mockk()
+    mockkObject(SecurityUtil)
+
+    val updateIntroduceUseCase = UpdateIntroduceUseCase(documentRepository)
+
+    describe("updateIntroduce") {
+
+        val student = anyValueObject<Student>()
+        val document = getTestDocument(student)
+
+        val request = anyValueObject<UpdateIntroduceRequest>()
+
+        context("자기소개 데이터를 받으면") {
+
+            val slot = slot<Document>()
+
+            every { SecurityUtil.getCurrentStudent() } returns student
+            every { documentRepository.findByWriterStudentId(student.id) } returns document
+            every { documentRepository.save(capture(slot)) } returnsArgument 0
+
+            it("본인(학생) 문서의 자기소개 정보를 수정한다.") {
+
+                updateIntroduceUseCase.execute(request)
+                onlyIntroduceIsDifferent(slot, document)
+            }
+        }
+    }
+
+    afterContainer()
+})
+
+private fun onlyIntroduceIsDifferent(
+    slot: CapturingSlot<Document>,
+    document: Document
+) {
+    slot.captured.id shouldBe document.id
+    slot.captured.writer shouldBe document.writer
+    slot.captured.introduce shouldNotBe document.introduce
+    slot.captured.skillSet shouldBe document.skillSet
+    slot.captured.projectList shouldBe document.projectList
+    slot.captured.awardList shouldBe document.awardList
+    slot.captured.certificateList shouldBe document.certificateList
+}

--- a/src/test/kotlin/kr/hs/entrydsm/exit/domain/document/usecase/UpdateProjectUseCaseTest.kt
+++ b/src/test/kotlin/kr/hs/entrydsm/exit/domain/document/usecase/UpdateProjectUseCaseTest.kt
@@ -1,0 +1,63 @@
+package kr.hs.entrydsm.exit.domain.document.usecase
+
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import io.mockk.*
+import kr.hs.entrydsm.exit.common.AnyValueObjectGenerator.anyValueObject
+import kr.hs.entrydsm.exit.common.afterContainer
+import kr.hs.entrydsm.exit.common.getTestDocument
+import kr.hs.entrydsm.exit.domain.document.persistence.Document
+import kr.hs.entrydsm.exit.domain.document.persistence.repository.DocumentRepository
+import kr.hs.entrydsm.exit.domain.document.presentation.dto.request.UpdateProjectRequest
+import kr.hs.entrydsm.exit.domain.document.presentation.dto.request.UpdateProjectRequest.ProjectRequest
+import kr.hs.entrydsm.exit.domain.student.persistence.Student
+import kr.hs.entrydsm.exit.global.security.SecurityUtil
+
+internal class UpdateProjectUseCaseTest : DescribeSpec({
+
+    val documentRepository: DocumentRepository = mockk()
+    mockkObject(SecurityUtil)
+
+    val updateProjectUseCase = UpdateProjectUseCase(documentRepository)
+
+    describe("updateProject") {
+
+        val student = anyValueObject<Student>()
+        val document = getTestDocument(student)
+
+        val request = anyValueObject<UpdateProjectRequest>(
+            "projectList" to listOf(anyValueObject<ProjectRequest>())
+        )
+
+        context("프로젝트 데이터를 받으면") {
+
+            val slot = slot<Document>()
+
+            every { SecurityUtil.getCurrentStudent() } returns student
+            every { documentRepository.findByWriterStudentId(student.id) } returns document
+            every { documentRepository.save(capture(slot)) } returnsArgument 0
+
+            it("본인(학생) 문서의 프로젝트 정보를 수정한다.") {
+
+                updateProjectUseCase.execute(request)
+                onlyProjectIsDifferent(slot, document)
+            }
+        }
+    }
+
+    afterContainer()
+})
+
+private fun onlyProjectIsDifferent(
+    slot: CapturingSlot<Document>,
+    document: Document
+) {
+    slot.captured.id shouldBe document.id
+    slot.captured.writer shouldBe document.writer
+    slot.captured.introduce shouldBe document.introduce
+    slot.captured.skillSet shouldBe document.skillSet
+    slot.captured.projectList shouldNotBe document.projectList
+    slot.captured.awardList shouldBe document.awardList
+    slot.captured.certificateList shouldBe document.certificateList
+}

--- a/src/test/kotlin/kr/hs/entrydsm/exit/domain/document/usecase/UpdateSkillSetUseCaseTest.kt
+++ b/src/test/kotlin/kr/hs/entrydsm/exit/domain/document/usecase/UpdateSkillSetUseCaseTest.kt
@@ -1,0 +1,62 @@
+package kr.hs.entrydsm.exit.domain.document.usecase
+
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import io.mockk.*
+import kr.hs.entrydsm.exit.common.AnyValueObjectGenerator.anyValueObject
+import kr.hs.entrydsm.exit.common.afterContainer
+import kr.hs.entrydsm.exit.common.getTestDocument
+import kr.hs.entrydsm.exit.domain.document.persistence.Document
+import kr.hs.entrydsm.exit.domain.document.persistence.repository.DocumentRepository
+import kr.hs.entrydsm.exit.domain.document.presentation.dto.request.UpdateSkillSetRequest
+import kr.hs.entrydsm.exit.domain.student.persistence.Student
+import kr.hs.entrydsm.exit.global.security.SecurityUtil
+
+internal class UpdateSkillSetUseCaseTest : DescribeSpec({
+
+    val documentRepository: DocumentRepository = mockk()
+    mockkObject(SecurityUtil)
+
+    val updateSkillSetUseCase = UpdateSkillSetUseCase(documentRepository)
+
+    describe("updateSkillSet") {
+
+        val student = anyValueObject<Student>()
+        val document = getTestDocument(student)
+
+        val request = anyValueObject<UpdateSkillSetRequest>(
+            "skillList" to listOf("Backend")
+        )
+
+        context("스킬셋 데이터를 받으면") {
+
+            val slot = slot<Document>()
+
+            every { SecurityUtil.getCurrentStudent() } returns student
+            every { documentRepository.findByWriterStudentId(student.id) } returns document
+            every { documentRepository.save(capture(slot)) } returnsArgument 0
+
+            it("본인(학생) 문서의 스킬셋 정보를 수정한다.") {
+
+                updateSkillSetUseCase.execute(request)
+                onlySkillSetIsDifferent(slot, document)
+            }
+        }
+    }
+
+    afterContainer()
+})
+
+private fun onlySkillSetIsDifferent(
+    slot: CapturingSlot<Document>,
+    document: Document
+) {
+    slot.captured.id shouldBe document.id
+    slot.captured.writer shouldBe document.writer
+    slot.captured.introduce shouldBe document.introduce
+    slot.captured.skillSet shouldNotBe document.skillSet
+    slot.captured.projectList shouldBe document.projectList
+    slot.captured.awardList shouldBe document.awardList
+    slot.captured.certificateList shouldBe document.certificateList
+}

--- a/src/test/kotlin/kr/hs/entrydsm/exit/domain/document/usecase/UpdateWriterInfoUseCaseTest.kt
+++ b/src/test/kotlin/kr/hs/entrydsm/exit/domain/document/usecase/UpdateWriterInfoUseCaseTest.kt
@@ -1,0 +1,72 @@
+package kr.hs.entrydsm.exit.domain.document.usecase
+
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import io.mockk.*
+import kr.hs.entrydsm.exit.common.AnyValueObjectGenerator.anyValueObject
+import kr.hs.entrydsm.exit.common.afterContainer
+import kr.hs.entrydsm.exit.common.getTestDocument
+import kr.hs.entrydsm.exit.domain.document.persistence.Document
+import kr.hs.entrydsm.exit.domain.document.persistence.repository.DocumentRepository
+import kr.hs.entrydsm.exit.domain.document.presentation.dto.request.UpdateWriterInfoRequest
+import kr.hs.entrydsm.exit.domain.major.persistence.Major
+import kr.hs.entrydsm.exit.domain.major.persistence.repository.MajorRepository
+import kr.hs.entrydsm.exit.domain.student.persistence.Student
+import kr.hs.entrydsm.exit.domain.student.persistence.repository.StudentRepository
+import kr.hs.entrydsm.exit.global.security.SecurityUtil
+import org.springframework.data.repository.findByIdOrNull
+
+internal class UpdateWriterInfoUseCaseTest : DescribeSpec({
+
+    val documentRepository: DocumentRepository = mockk()
+    val studentRepository: StudentRepository = mockk()
+    val majorRepository: MajorRepository = mockk()
+    mockkObject(SecurityUtil)
+
+    val updateWriterInfoUseCase = UpdateWriterInfoUseCase(documentRepository, studentRepository, majorRepository)
+
+    describe("updateWriterInfo") {
+
+        val student = anyValueObject<Student>()
+        val document = getTestDocument(student)
+        val major = anyValueObject<Major>()
+
+        val request = anyValueObject<UpdateWriterInfoRequest>()
+
+        context("작성자 정보 데이터를 받으면") {
+
+            val slot = slot<Document>()
+
+            every { SecurityUtil.getCurrentStudent() } returns student
+            every { documentRepository.findByWriterStudentId(student.id) } returns document
+            every { majorRepository.findByIdOrNull(request.majorId) } returns major
+            every { documentRepository.save(capture(slot)) } returnsArgument 0
+            every { studentRepository.save(any()) } returnsArgument 0
+
+            it("본인(학생) 문서의 작성자 정보를 수정한다.") {
+
+                updateWriterInfoUseCase.execute(request)
+
+                verify(exactly = 1) { documentRepository.save(slot.captured) }
+                verify(exactly = 1) { studentRepository.save(any()) }
+                onlyWriterIsDifferent(slot, document)
+            }
+        }
+    }
+
+    afterContainer()
+})
+
+private fun onlyWriterIsDifferent(
+    slot: CapturingSlot<Document>,
+    document: Document
+) {
+    slot.captured.id shouldBe document.id
+    slot.captured.writer shouldNotBe document.writer
+    slot.captured.introduce shouldBe document.introduce
+    slot.captured.skillSet shouldBe document.skillSet
+    slot.captured.projectList shouldBe document.projectList
+    slot.captured.awardList shouldBe document.awardList
+    slot.captured.certificateList shouldBe document.certificateList
+}

--- a/src/test/kotlin/kr/hs/entrydsm/exit/domain/student/usecase/StudentGoogleOauthUseCaseTest.kt
+++ b/src/test/kotlin/kr/hs/entrydsm/exit/domain/student/usecase/StudentGoogleOauthUseCaseTest.kt
@@ -1,0 +1,105 @@
+package kr.hs.entrydsm.exit.domain.student.usecase
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import kr.hs.entrydsm.exit.common.AnyValueObjectGenerator.anyValueObject
+import kr.hs.entrydsm.exit.common.afterContainer
+import kr.hs.entrydsm.exit.domain.auth.Authority
+import kr.hs.entrydsm.exit.domain.auth.dto.response.TokenResponse
+import kr.hs.entrydsm.exit.domain.common.exception.EmailSuffixNotValidException
+import kr.hs.entrydsm.exit.domain.student.exception.SignUpRequiredRedirection
+import kr.hs.entrydsm.exit.domain.student.persistence.Student
+import kr.hs.entrydsm.exit.domain.student.persistence.repository.StudentRepository
+import kr.hs.entrydsm.exit.global.oauth.GoogleAuth
+import kr.hs.entrydsm.exit.global.oauth.GoogleEmail
+import kr.hs.entrydsm.exit.global.oauth.dto.response.GoogleAccessTokenResponse
+import kr.hs.entrydsm.exit.global.oauth.dto.response.GoogleEmailResponse
+import kr.hs.entrydsm.exit.global.oauth.properties.GoogleOauthProperties
+import kr.hs.entrydsm.exit.global.security.jwt.JwtGenerator
+import java.time.LocalDateTime
+
+internal class StudentGoogleOauthUseCaseTest : DescribeSpec({
+
+    val studentRepository = mockk<StudentRepository>()
+    val googleProperties = GoogleOauthProperties("","","","")
+    val googleAuth =  mockk<GoogleAuth>()
+    val googleEmail = mockk<GoogleEmail>()
+    val jwtGenerator = mockk<JwtGenerator>()
+
+    val studentGoogleOauthUseCase = StudentGoogleOauthUseCase(
+        studentRepository,
+        googleProperties,
+        googleAuth,
+        googleEmail,
+        jwtGenerator
+    )
+
+    describe("studentGoogleOauth") {
+
+        val code = "code"
+        val googleAccessToken = "google_access_token"
+        val email = "email@dsm.hs.kr"
+        val student = anyValueObject<Student>(
+            "email" to email
+        )
+
+        val tokenResponse = TokenResponse (
+            accessToken = "access_token",
+            accessExpiredAt = LocalDateTime.MAX,
+            refreshToken = "refresh_token",
+            refreshExpiredAt = LocalDateTime.MAX
+        )
+
+        context("가입된 유저의 Oauth 코드가 주어지면") {
+
+            every { googleAuth.queryAccessToken(code, any(), any(), any(), any()) } returns GoogleAccessTokenResponse(
+                googleAccessToken
+            )
+            every { googleEmail.getEmail(googleAccessToken, any()) } returns GoogleEmailResponse(email)
+            every { studentRepository.findByEmail(email) } returns student
+            every { jwtGenerator.generateBothToken(student.id, Authority.STUDENT) } returns tokenResponse
+
+            it("토큰을 반환한다.") {
+                val response = studentGoogleOauthUseCase.signUpOrIn(code)
+                response shouldBe tokenResponse
+            }
+        }
+
+        context("가입되지 않은 유저의 Oauth 코드가 주어지면") {
+
+            every { googleAuth.queryAccessToken(code, any(), any(), any(), any()) } returns GoogleAccessTokenResponse(
+                googleAccessToken
+            )
+            every { googleEmail.getEmail(googleAccessToken, any()) } returns GoogleEmailResponse(email)
+            every { studentRepository.findByEmail(email) } returns null
+
+            it("SignUpRequiredRedirection를 던진다.") {
+                shouldThrow<SignUpRequiredRedirection> {
+                    studentGoogleOauthUseCase.signUpOrIn(code)
+                }
+            }
+        }
+
+        context("학교 이메일이 아닌 Oauth 코드가 주어지면") {
+
+            val gmail = "email@gmail.com"
+
+            every { googleAuth.queryAccessToken(code, any(), any(), any(), any()) } returns GoogleAccessTokenResponse(
+                googleAccessToken
+            )
+            every { googleEmail.getEmail(googleAccessToken, any()) } returns GoogleEmailResponse(gmail)
+
+            it("EmailSuffixNotValid 예외를 던진다.") {
+                shouldThrow<EmailSuffixNotValidException> {
+                    studentGoogleOauthUseCase.signUpOrIn(code)
+                }
+            }
+        }
+
+    }
+
+    afterContainer()
+})


### PR DESCRIPTION
close #26 

지금까지 만든 UseCase 테스트코드입니다. (major 제외)

- Test 라이브러리는 kotlin 람다, dsl 문법 활용하기 위해 kotest와 mokk 사용했습니다.

- AnyValueObjectGenerator의 anyValueObject 메서드는 reflection(inline fun)과 제네릭을 활용해서 임의의 값을 가진 객체를 만드는 메서드입니다.
1. vararg pairs: Pair<String, Any>로 받은 List를 map으로 바꾸고,
2. 각 파라미터 이름에 맞는 객체를 map에서 꺼내 타입에 맞는 임의 값(anyValue)을 받아온 다음
3. `params`에 넣어 spread operator로 생성자 호출하는 방식으로 구현했습니다.

+ 전화번호 인증번호 발송 부분에서 countOfSend가 증가되지 않는 것 같아 저장시 +1 해주도록 변경했습니다