### PR TITLE
(#38) :: 문서 조회 api 

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,6 +3,7 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 plugins {
     id("org.springframework.boot") version "2.7.5"
     id("io.spring.dependency-management") version "1.0.15.RELEASE"
+    id("com.ewerk.gradle.plugins.querydsl") version "1.0.10"
 
     kotlin("jvm") version "1.6.21"
     kotlin("plugin.spring") version "1.6.21"
@@ -41,29 +42,38 @@ dependencies {
     // validation
     implementation("org.springframework.boot:spring-boot-starter-validation")
 
-    // Fegin Client
-    implementation("io.github.openfeign:feign-httpclient:11.9.1")
-    implementation("org.springframework.cloud:spring-cloud-starter-openfeign:3.1.4")
-
-    // cool sms
-    implementation("net.nurigo:javaSDK:2.2")
-    
-    //AWS
-    implementation("org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE")
-
     // DB
     implementation("org.springframework.boot:spring-boot-starter-data-jpa")
     runtimeOnly("com.mysql:mysql-connector-j")
 
     implementation("org.springframework.boot:spring-boot-starter-data-redis")
 
-    implementation("org.springframework.boot:spring-boot-starter-data-mongodb:2.6.3")
-    runtimeOnly("org.mongodb:mongodb-driver-sync:4.8.1")
+    implementation("org.springframework.boot:spring-boot-starter-data-mongodb")
+    implementation("org.mongodb:mongodb-driver-sync:4.6.0")
+
+    // querydsl
+    implementation("com.querydsl:querydsl-mongodb:5.0.0")
+    api("com.querydsl:querydsl-jpa:5.0.0")
+    kapt("com.querydsl:querydsl-apt:5.0.0")
+
+    // Fegin Client
+    implementation("io.github.openfeign:feign-httpclient:11.9.1")
+    implementation("org.springframework.cloud:spring-cloud-starter-openfeign:3.1.4")
+
+    // AWS
+    implementation("org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE")
+
+    // cool sms
+    implementation("net.nurigo:javaSDK:2.2")
 
     // test
-    testImplementation("io.kotest:kotest-runner-junit5:5.5.4")
-    testImplementation("io.mockk:mockk:1.13.2")
+    testImplementation("org.springframework.boot:spring-boot-starter-test")
 
+    testImplementation("io.kotest:kotest-runner-junit5-jvm:4.4.3")
+    testImplementation("io.kotest:kotest-assertions-core-jvm:4.4.3")
+    testImplementation("io.kotest:kotest-extensions-spring:4.4.3")
+
+    testImplementation("io.mockk:mockk:1.13.2")
 }
 
 allOpen {
@@ -71,6 +81,18 @@ allOpen {
     annotation("javax.persistence.MappedSuperclass")
     annotation("javax.persistence.Embeddable")
     annotation("org.springframework.data.mongodb.core.mapping.Document")
+}
+
+kapt {
+    annotationProcessor("org.springframework.data.mongodb.repository.support.MongoAnnotationProcessor")
+    annotationProcessor("com.querydsl.apt.jpa.JPAAnnotationProcessor")
+}
+
+querydsl {
+    springDataMongo = true
+    jpa = true
+    library = "com.querydsl:querydsl-apt:5.0.0"
+    querydslSourcesDir = "$projectDir/build/generated"
 }
 
 tasks.withType<KotlinCompile> {

--- a/src/main/kotlin/kr/hs/entrydsm/exit/domain/common/DomainErrorCode.kt
+++ b/src/main/kotlin/kr/hs/entrydsm/exit/domain/common/DomainErrorCode.kt
@@ -25,8 +25,10 @@ enum class DomainErrorCode(
     ALREADY_VERIFIED_EXCEPTION(409, "AUTH-409-1", "Is Alreadt verified"),
     TOO_MANY_SEND_VERIFICATION_CODE(429, "AUTH-429-1", "Too Many Send Verification Code / Please Confirm Later"),
 
+    DOCUMENT_ACCESS_RIGHT(403, "DOCUMENT-403-1", "Have No Access To Documents"),
     DOCUMENT_NOT_FOUND(404, "DOCUMENT-404-1", "Document Not Found"),
     DOCUMENT_ALREADY_EXIST(409, "DOCUMENT-409-1", "Document Already Exist"),
+    ILLEGAL_STATUS(409, "DOCUMENT-409-2", "Unable To Perform This Action"),
 
     MAJOR_NOT_FOUND(404, "MAJOR-404-1", "Major Not Found"),
 

--- a/src/main/kotlin/kr/hs/entrydsm/exit/domain/common/annotation/ReadOnlyUseCase.kt
+++ b/src/main/kotlin/kr/hs/entrydsm/exit/domain/common/annotation/ReadOnlyUseCase.kt
@@ -1,0 +1,10 @@
+package kr.hs.entrydsm.exit.domain.common.annotation
+
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Target(AnnotationTarget.CLASS)
+@Retention(AnnotationRetention.RUNTIME)
+@Service
+@Transactional(readOnly = true)
+annotation class ReadOnlyUseCase

--- a/src/main/kotlin/kr/hs/entrydsm/exit/domain/document/exception/DocumentAccessRightException.kt
+++ b/src/main/kotlin/kr/hs/entrydsm/exit/domain/document/exception/DocumentAccessRightException.kt
@@ -1,0 +1,8 @@
+package kr.hs.entrydsm.exit.domain.document.exception
+
+import kr.hs.entrydsm.exit.domain.common.DomainErrorCode
+import kr.hs.entrydsm.exit.domain.common.error.DomainCustomException
+
+object DocumentAccessRightException : DomainCustomException(
+    DomainErrorCode.DOCUMENT_ACCESS_RIGHT
+)

--- a/src/main/kotlin/kr/hs/entrydsm/exit/domain/document/exception/IllegalStatusException.kt
+++ b/src/main/kotlin/kr/hs/entrydsm/exit/domain/document/exception/IllegalStatusException.kt
@@ -1,0 +1,8 @@
+package kr.hs.entrydsm.exit.domain.document.exception
+
+import kr.hs.entrydsm.exit.domain.common.DomainErrorCode
+import kr.hs.entrydsm.exit.domain.common.error.DomainCustomException
+
+object IllegalStatusException : DomainCustomException(
+    DomainErrorCode.ILLEGAL_STATUS
+)

--- a/src/main/kotlin/kr/hs/entrydsm/exit/domain/document/persistence/repository/DocumentRepository.kt
+++ b/src/main/kotlin/kr/hs/entrydsm/exit/domain/document/persistence/repository/DocumentRepository.kt
@@ -3,10 +3,13 @@ package kr.hs.entrydsm.exit.domain.document.persistence.repository
 
 import kr.hs.entrydsm.exit.domain.document.persistence.Document
 import org.springframework.data.mongodb.repository.MongoRepository
+import org.springframework.data.querydsl.QuerydslPredicateExecutor
 import java.util.*
 
 
-interface DocumentRepository: MongoRepository<Document, UUID> {
+interface DocumentRepository: MongoRepository<Document, UUID>, QuerydslPredicateExecutor<Document> {
+
     fun findByWriterStudentId(studentId: UUID): Document?
+
     fun findByIdAndWriterStudentId(id: UUID, studentId: UUID): Document?
 }

--- a/src/main/kotlin/kr/hs/entrydsm/exit/domain/document/persistence/repository/DocumentRepositoryExtensions.kt
+++ b/src/main/kotlin/kr/hs/entrydsm/exit/domain/document/persistence/repository/DocumentRepositoryExtensions.kt
@@ -1,0 +1,52 @@
+package kr.hs.entrydsm.exit.domain.document.persistence.repository
+
+import com.querydsl.core.types.dsl.BooleanExpression
+import kr.hs.entrydsm.exit.domain.document.persistence.Document
+import kr.hs.entrydsm.exit.domain.document.persistence.QDocument.document
+import kr.hs.entrydsm.exit.domain.document.persistence.enums.Status
+import kr.hs.entrydsm.exit.global.config.querydsl.findBy
+import java.util.*
+
+fun DocumentRepository.findByStatusAndWriterInfo(
+    status: Status,
+    name: String,
+    grade: String?,
+    classNum: String?,
+    majorId: UUID?
+): List<Document> {
+
+    return findBy(
+        document.status.eq(status),
+        document.writer.name.contains(name),
+        eqGrade(grade),
+        eqClassNum(classNum),
+        eqMajorId(majorId)
+    )
+}
+
+fun DocumentRepository.findByWriterInfo(
+    name: String,
+    grade: String?,
+    classNum: String?,
+    majorId: UUID?
+): List<Document> {
+
+    return findBy(
+        document.writer.name.contains(name),
+        eqGrade(grade),
+        eqClassNum(classNum),
+        eqMajorId(majorId)
+    )
+}
+
+private fun eqGrade(grade: String?): BooleanExpression? {
+    return if (grade != null) document.writer.grade.eq(grade) else null
+}
+
+private fun eqClassNum(classNum: String?): BooleanExpression? {
+    return if (classNum != null) document.writer.classNum.eq(classNum) else null
+}
+
+private fun eqMajorId(majorId: UUID?): BooleanExpression? {
+    return if (majorId != null) document.writer.majorId.eq(majorId) else null
+}

--- a/src/main/kotlin/kr/hs/entrydsm/exit/domain/document/presentation/dto/request/QueryDocumentRequest.kt
+++ b/src/main/kotlin/kr/hs/entrydsm/exit/domain/document/presentation/dto/request/QueryDocumentRequest.kt
@@ -1,0 +1,14 @@
+package kr.hs.entrydsm.exit.domain.document.presentation.dto.request
+
+import java.util.*
+
+data class QueryDocumentRequest(
+
+    val name: String = "",
+
+    val grade: String?,
+
+    val classNum: String?,
+
+    val majorId: UUID?
+)

--- a/src/main/kotlin/kr/hs/entrydsm/exit/domain/document/presentation/dto/response/DocumentInfoResponse.kt
+++ b/src/main/kotlin/kr/hs/entrydsm/exit/domain/document/presentation/dto/response/DocumentInfoResponse.kt
@@ -1,0 +1,126 @@
+package kr.hs.entrydsm.exit.domain.document.presentation.dto.response
+
+import kr.hs.entrydsm.exit.domain.document.persistence.Document
+import kr.hs.entrydsm.exit.domain.document.persistence.element.*
+import kr.hs.entrydsm.exit.domain.document.persistence.enums.Status
+import kr.hs.entrydsm.exit.domain.major.presentation.dto.response.MajorVO
+import java.util.*
+
+data class DocumentInfoResponse(
+
+    val documentId: UUID,
+
+    val writer: WriterInfoResponse,
+
+    val status: Status,
+
+    val introduce: IntroduceResponse,
+
+    val skillSet: List<String>,
+
+    val projectList: List<ProjectResponse>,
+
+    val awardList: List<AwardResponse>,
+
+    val certificateList: List<CertificateResponse>
+) {
+    constructor(document: Document) : this(
+        documentId = document.id,
+        writer = WriterInfoResponse(document.writer),
+        status = document.status,
+        introduce = IntroduceResponse(document.introduce),
+        skillSet = document.skillSet,
+        projectList = document.projectList.map { ProjectResponse(it) },
+        awardList = document.awardList.map { AwardResponse(it) },
+        certificateList = document.certificateList.map { CertificateResponse(it) }
+    )
+
+    data class WriterInfoResponse(
+        val elementId: UUID,
+        val studentId: UUID,
+        val name: String,
+        val profileImagePath: String,
+        val studentNumber: String,
+        val email: String,
+        val major: MajorVO
+    ) {
+        constructor(element: WriterInfoElement) : this(
+            elementId = element.elementId,
+            studentId = element.studentId,
+            name = element.name,
+            profileImagePath = element.profileImagePath,
+            studentNumber = element.studentNumber,
+            email = element.email,
+            major = MajorVO(
+                id = element.majorId,
+                name = element.majorName
+            )
+        )
+    }
+
+    data class IntroduceResponse(
+        val elementId: UUID,
+        val heading: String,
+        val introduce: String
+    ) {
+        constructor(element: IntroduceElement) : this(
+            elementId = element.elementId,
+            heading = element.heading,
+            introduce = element.introduce
+        )
+    }
+
+    data class ProjectResponse(
+        val elementId: UUID,
+        val name: String,
+        val representImagePath: String,
+        val startDate: Date,
+        val endDate: Date,
+        val skillSet: List<String>,
+        val description: String,
+        val url: String?
+    ) {
+        constructor(element: ProjectElement) : this(
+            elementId = element.elementId,
+            name = element.name,
+            representImagePath = element.representImagePath,
+            startDate = element.startDate,
+            endDate = element.endDate,
+            skillSet = element.skillSet,
+            description = element.description,
+            url = element.url
+        )
+    }
+
+    data class AwardResponse(
+        val elementId: UUID,
+        val name: String,
+        val awardingInstitution: String,
+        val date: Date,
+        val description: String?,
+        val url: String?
+    ) {
+        constructor(element: AwardElement) : this(
+            elementId = element.elementId,
+            name = element.name,
+            awardingInstitution = element.awardingInstitution,
+            date = element.date,
+            description = element.description,
+            url = element.url
+        )
+    }
+
+    data class CertificateResponse(
+        val elementId: UUID,
+        val name: String,
+        val issuingInstitution: String,
+        val date: Date
+    ) {
+        constructor(element: CertificateElement) : this(
+            elementId = element.elementId,
+            name = element.name,
+            issuingInstitution = element.issuingInstitution,
+            date = element.date
+        )
+    }
+}

--- a/src/main/kotlin/kr/hs/entrydsm/exit/domain/document/presentation/dto/response/DocumentListResponse.kt
+++ b/src/main/kotlin/kr/hs/entrydsm/exit/domain/document/presentation/dto/response/DocumentListResponse.kt
@@ -1,0 +1,28 @@
+package kr.hs.entrydsm.exit.domain.document.presentation.dto.response
+
+import kr.hs.entrydsm.exit.domain.document.persistence.Document
+import kr.hs.entrydsm.exit.domain.major.presentation.dto.response.MajorVO
+
+data class DocumentListResponse(
+    val documentList: List<DocumentResponse>
+) {
+    data class DocumentResponse(
+        val name: String,
+        val profileImagePath: String,
+        val studentNumber: String,
+        val email: String,
+        val major: MajorVO
+    ) {
+        constructor(document: Document): this(
+            name = document.writer.name,
+            profileImagePath = document.writer.profileImagePath,
+            studentNumber = document.writer.studentNumber,
+            email = document.writer.email,
+            major = MajorVO(
+                id = document.writer.majorId,
+                name = document.writer.majorName
+            )
+        )
+    }
+}
+

--- a/src/main/kotlin/kr/hs/entrydsm/exit/domain/document/usecase/QueryDocumentInfoUseCase.kt
+++ b/src/main/kotlin/kr/hs/entrydsm/exit/domain/document/usecase/QueryDocumentInfoUseCase.kt
@@ -1,0 +1,48 @@
+package kr.hs.entrydsm.exit.domain.document.usecase
+
+import kr.hs.entrydsm.exit.domain.auth.Authority
+import kr.hs.entrydsm.exit.domain.auth.Authority.TEACHER
+import kr.hs.entrydsm.exit.domain.common.annotation.ReadOnlyUseCase
+import kr.hs.entrydsm.exit.domain.document.exception.DocumentAccessRightException
+import kr.hs.entrydsm.exit.domain.document.exception.DocumentNotFoundException
+import kr.hs.entrydsm.exit.domain.document.persistence.Document
+import kr.hs.entrydsm.exit.domain.document.persistence.enums.Status
+import kr.hs.entrydsm.exit.domain.document.persistence.repository.DocumentRepository
+import kr.hs.entrydsm.exit.domain.document.presentation.dto.response.DocumentInfoResponse
+import kr.hs.entrydsm.exit.domain.student.persistence.repository.StudentRepository
+import kr.hs.entrydsm.exit.global.security.SecurityUtil
+import org.springframework.data.repository.findByIdOrNull
+import java.util.*
+
+@ReadOnlyUseCase
+class QueryDocumentInfoUseCase(
+    private val documentRepository: DocumentRepository,
+    private val studentRepository: StudentRepository
+) {
+
+    fun execute(documentId: UUID): DocumentInfoResponse {
+
+        val authority = SecurityUtil.getCurrentUserAuthority()
+        
+        val document = documentRepository.findByIdOrNull(documentId) ?: throw DocumentNotFoundException
+
+        if(!isWriter(document) && !hasAccess(document.status, authority)) {
+            throw DocumentAccessRightException
+        }
+
+        return DocumentInfoResponse(document)
+    }
+
+    private fun hasAccess(status: Status, authority: Authority): Boolean {
+        return when(status) {
+            Status.CREATED -> false
+            Status.SUBMITTED -> authority == TEACHER
+            Status.SHARED -> true
+        }
+    }
+
+    private fun isWriter(document: Document) : Boolean {
+        val student = studentRepository.findByIdOrNull(SecurityUtil.getCurrentUserId())
+        return document.isWriter(student)
+    }
+}

--- a/src/main/kotlin/kr/hs/entrydsm/exit/domain/document/usecase/QueryMyDocumentInfoUseCase.kt
+++ b/src/main/kotlin/kr/hs/entrydsm/exit/domain/document/usecase/QueryMyDocumentInfoUseCase.kt
@@ -1,0 +1,21 @@
+package kr.hs.entrydsm.exit.domain.document.usecase
+
+import kr.hs.entrydsm.exit.domain.common.annotation.ReadOnlyUseCase
+import kr.hs.entrydsm.exit.domain.document.exception.DocumentNotFoundException
+import kr.hs.entrydsm.exit.domain.document.persistence.repository.DocumentRepository
+import kr.hs.entrydsm.exit.domain.document.presentation.dto.response.DocumentInfoResponse
+import kr.hs.entrydsm.exit.global.security.SecurityUtil
+
+@ReadOnlyUseCase
+class QueryMyDocumentInfoUseCase(
+    private val documentRepository: DocumentRepository
+) {
+
+    fun execute(): DocumentInfoResponse {
+
+        val student = SecurityUtil.getCurrentStudent()
+        val document = documentRepository.findByWriterStudentId(student.id) ?: throw DocumentNotFoundException
+
+        return DocumentInfoResponse(document)
+    }
+}

--- a/src/main/kotlin/kr/hs/entrydsm/exit/domain/document/usecase/QuerySharedDocumentUseCase.kt
+++ b/src/main/kotlin/kr/hs/entrydsm/exit/domain/document/usecase/QuerySharedDocumentUseCase.kt
@@ -1,0 +1,34 @@
+package kr.hs.entrydsm.exit.domain.document.usecase
+
+import kr.hs.entrydsm.exit.domain.common.annotation.ReadOnlyUseCase
+import kr.hs.entrydsm.exit.domain.document.persistence.enums.Status
+import kr.hs.entrydsm.exit.domain.document.persistence.repository.DocumentRepository
+import kr.hs.entrydsm.exit.domain.document.persistence.repository.findByStatusAndWriterInfo
+import kr.hs.entrydsm.exit.domain.document.presentation.dto.request.QueryDocumentRequest
+import kr.hs.entrydsm.exit.domain.document.presentation.dto.response.DocumentListResponse
+import kr.hs.entrydsm.exit.domain.document.presentation.dto.response.DocumentListResponse.DocumentResponse
+
+@ReadOnlyUseCase
+class QuerySharedDocumentUseCase(
+    private val documentRepository: DocumentRepository
+) {
+
+    fun execute(request: QueryDocumentRequest): DocumentListResponse {
+
+        val documentList = request.run {
+            documentRepository.findByStatusAndWriterInfo(
+                status = Status.SHARED,
+                name = name,
+                grade = grade,
+                classNum = classNum,
+                majorId = request.majorId
+            )
+        }
+
+        return DocumentListResponse(
+            documentList.map {
+                DocumentResponse(it)
+            }
+        )
+    }
+}

--- a/src/main/kotlin/kr/hs/entrydsm/exit/global/config/MongoDBConfig.kt
+++ b/src/main/kotlin/kr/hs/entrydsm/exit/global/config/MongoDBConfig.kt
@@ -1,0 +1,24 @@
+package kr.hs.entrydsm.exit.global.config
+
+import com.mongodb.client.MongoClient
+import org.springframework.boot.autoconfigure.mongo.MongoProperties
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.data.mongodb.MongoDatabaseFactory
+import org.springframework.data.mongodb.core.MongoTemplate
+import org.springframework.data.mongodb.core.SimpleMongoClientDatabaseFactory
+import org.springframework.data.mongodb.repository.config.EnableMongoRepositories
+
+@Configuration
+@EnableMongoRepositories(basePackages = ["kr.hs.entrydsm.exit"], mongoTemplateRef = "blogMongoTemplate")
+class MongoDBConfig(
+    private val mongoProperties: MongoProperties
+) {
+
+    @Bean
+    fun blogMongoTemplate(mongoClient: MongoClient): MongoTemplate {
+        val factory: MongoDatabaseFactory = SimpleMongoClientDatabaseFactory(mongoClient, mongoProperties.database)
+        return MongoTemplate(factory)
+    }
+
+}

--- a/src/main/kotlin/kr/hs/entrydsm/exit/global/config/querydsl/QuerydslConfig.kt
+++ b/src/main/kotlin/kr/hs/entrydsm/exit/global/config/querydsl/QuerydslConfig.kt
@@ -1,0 +1,20 @@
+package kr.hs.entrydsm.exit.global.config.querydsl
+
+import com.querydsl.jpa.impl.JPAQueryFactory
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import javax.persistence.EntityManager
+import javax.persistence.PersistenceContext
+
+@Configuration
+class QuerydslConfig(
+    @PersistenceContext
+    private val entityManager: EntityManager
+) {
+
+    @Bean
+    fun JPAQueryFactory(): JPAQueryFactory {
+        return JPAQueryFactory(entityManager)
+    }
+
+}

--- a/src/main/kotlin/kr/hs/entrydsm/exit/global/config/querydsl/QuerydslExtensions.kt
+++ b/src/main/kotlin/kr/hs/entrydsm/exit/global/config/querydsl/QuerydslExtensions.kt
@@ -1,0 +1,12 @@
+package kr.hs.entrydsm.exit.global.config.querydsl
+
+import com.querydsl.core.types.dsl.BooleanExpression
+import org.springframework.data.querydsl.QuerydslPredicateExecutor
+
+fun <T> QuerydslPredicateExecutor<T>.findBy(vararg expressions: BooleanExpression?): List<T> {
+
+    var predicate = expressions[0]!!
+    expressions.forEach { predicate = predicate.and(it) }
+
+    return findAll(predicate).toList()
+}


### PR DESCRIPTION
close #38

### 작업내용 

- 내 문서 상세 조회
- 공개된 문서 목록 조회
- 문서 상세 조회

---

### 참고사항

- 문서 상세 조회 권한
    - CREATED: 작성자만
    - SUBMITED: 작성자, 선생님
    - SHARED: 전체

- querydsl 써서 이름, 학년, 반, 전공 조건 넣어서 동적으로 조회할 수 있게 했습니다. (일부 조건 null이어도 됨)
- mongoTemplate을 빈으로 주입받아 직접 사용하는 대신, repository에 `QuerydslPredicateExecutor`를 상속받아서 확장함수 형태로 구현했습니다.
    - 그리고 QuerydslPredicateExecutor에 대한 확장함수 `findBy`를 만들어 다중인자로 조건을 받을 수 있도록 했습니다.
    - 그렇기 때문에 함수를 짤 때 jpa querydsl를 사용하는 것과 최대한 비슷하게 사용할 수 있습니다.

다른 구조에 대한 아이디어 있으시면 말씀해주세요.
